### PR TITLE
fix: restore production signup and downloads

### DIFF
--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -1,4 +1,4 @@
-import WaitlistPage from "@/components/WaitlistPage";
+import AuthPage from "@/components/AuthPage";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
@@ -6,10 +6,10 @@ type Props = { params: Promise<{ locale: string }> };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "landing" });
+  const t = await getTranslations({ locale, namespace: "auth" });
   return {
-    title: t("waitlistTitle"),
-    description: t("waitlistSub"),
+    title: t("signupTitle"),
+    description: t("signupSub"),
     alternates: { canonical: `https://trytoone.com/${locale}/signup` },
     robots: { index: false, follow: true },
   };
@@ -18,5 +18,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function SignUpPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
-  return <WaitlistPage />;
+  return <AuthPage mode="signup" />;
 }

--- a/components/AuthenticatedDownloadGrid.tsx
+++ b/components/AuthenticatedDownloadGrid.tsx
@@ -6,13 +6,19 @@ import { Link } from "@/lib/navigation";
 import {
   ApiError,
   clearSession,
-  getDesktopDownload,
   getMe,
   loadSession,
   type ToneSession,
 } from "@/lib/api";
 
 type Variant = "standard" | "liquid-glass";
+
+const DOWNLOAD_URLS: Record<Variant, string> = {
+  standard:
+    "https://github.com/io-hexagonal/Toone/releases/latest/download/Toone.dmg",
+  "liquid-glass":
+    "https://github.com/io-hexagonal/Toone/releases/latest/download/Toone-Liquid-Glass.dmg",
+};
 
 type Copy = {
   choicesLabel: string;
@@ -41,8 +47,6 @@ export default function AuthenticatedDownloadGrid({ copy }: { copy: Copy }) {
   const [session, setSession] = useState<ToneSession | null>(null);
   const [checking, setChecking] = useState(true);
   const [validationError, setValidationError] = useState(false);
-  const [preparing, setPreparing] = useState<Variant | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const persisted = loadSession();
@@ -74,26 +78,6 @@ export default function AuthenticatedDownloadGrid({ copy }: { copy: Copy }) {
     };
   }, []);
 
-  async function download(variant: Variant) {
-    if (!session || preparing) return;
-    setPreparing(variant);
-    setError(null);
-    try {
-      const artifact = await getDesktopDownload(variant, session.token);
-      window.location.assign(artifact.url);
-    } catch (caught) {
-      if (
-        caught instanceof ApiError &&
-        ["unauthorized", "invalid_token", "token_expired"].includes(caught.code)
-      ) {
-        clearSession();
-        setSession(null);
-      }
-      setError(auth("errGeneric"));
-      setPreparing(null);
-    }
-  }
-
   if (checking) {
     return <div className="download-access" aria-busy="true">…</div>;
   }
@@ -112,7 +96,7 @@ export default function AuthenticatedDownloadGrid({ copy }: { copy: Copy }) {
         <h2>{auth("signinTitle")}</h2>
         <p>{auth("signinSub")}</p>
         <Link className="download-button" href="/signin">{auth("signinBtn")}</Link>
-        <Link className="download-waitlist-link" href="/signup">{auth("signupLink")}</Link>
+        <Link className="download-waitlist-link" href="/signup">{auth("signupTitle")}</Link>
       </div>
     );
   }
@@ -136,16 +120,14 @@ export default function AuthenticatedDownloadGrid({ copy }: { copy: Copy }) {
           </div>
           <div className="download-requirement"><AppleLogo />{copy.standardRequirement}</div>
           <p>{copy.standardDescription}</p>
-          <button
+          <a
             className="download-button"
-            type="button"
-            disabled={preparing !== null}
-            onClick={() => void download("standard")}
+            href={DOWNLOAD_URLS.standard}
             data-umami-event="download-dmg-standard"
             data-umami-event-placement="download-page"
           >
-            {preparing === "standard" ? "…" : copy.standardButton}
-          </button>
+            {copy.standardButton}
+          </a>
         </article>
 
         <article className="download-card liquid">
@@ -164,19 +146,16 @@ export default function AuthenticatedDownloadGrid({ copy }: { copy: Copy }) {
           </div>
           <div className="download-requirement"><AppleLogo />{copy.liquidRequirement}</div>
           <p>{copy.liquidDescription}</p>
-          <button
+          <a
             className="download-button"
-            type="button"
-            disabled={preparing !== null}
-            onClick={() => void download("liquid-glass")}
+            href={DOWNLOAD_URLS["liquid-glass"]}
             data-umami-event="download-dmg-liquid-glass"
             data-umami-event-placement="download-page"
           >
-            {preparing === "liquid-glass" ? "…" : copy.liquidButton}
-          </button>
+            {copy.liquidButton}
+          </a>
         </article>
       </section>
-      {error && <p className="download-error" role="alert">{error}</p>}
     </>
   );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -69,11 +69,6 @@ type RawAuthPayload = {
   IsNewUser?: boolean;
 };
 
-type RawDesktopDownload = {
-  URL: string;
-  ExpiresAt: string;
-};
-
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${apiBase()}${path}`, init);
   if (res.status === 204) return undefined as T;
@@ -199,17 +194,6 @@ export async function getMe(token: string): Promise<ToneUser> {
     headers: { Authorization: `Bearer ${token}` },
   });
   return { id: raw.ID, email: raw.Email, name: raw.Name };
-}
-
-export async function getDesktopDownload(
-  variant: "standard" | "liquid-glass",
-  token: string,
-): Promise<{ url: string; expiresAt: string }> {
-  const raw = await request<RawDesktopDownload>(`/downloads/desktop/${variant}`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return { url: raw.URL, expiresAt: raw.ExpiresAt };
 }
 
 export async function logout(token: string): Promise<void> {


### PR DESCRIPTION
Restores the account-creation page now that production registration is open, and sends authenticated download buttons to the stable public GitHub assets. This removes the dead API call that currently returns 404 for both desktop variants.\n\nValidated with content publication checks, TypeScript, and a production Next.js build.